### PR TITLE
Output better error messages using information available from anyhow

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,3 +1,5 @@
+use anyhow::Context;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde_derive::Deserialize)]
 #[allow(non_camel_case_types)]
 pub enum Arch {
@@ -128,7 +130,9 @@ impl<'a> Builder<'a> {
                     tokio::fs::remove_file(symlink_package_path).await?;
                 }
                 log::info!("Copy {} to {}", entry.path().display(), dest.display());
-                tokio::fs::copy(entry.path(), &dest).await?;
+                tokio::fs::copy(entry.path(), &dest)
+                    .await
+                    .with_context(|| format!("Unable to copy file {:?} to {:?}", entry.path(), dest))?;
                 if let Some(signer) = self.signer {
                     let mut sig_dest = dest.clone().into_os_string();
                     sig_dest.push(".sig");


### PR DESCRIPTION
If the main function returns an error, it will be nicely printed for the user by rust.

This isn't a very high priority for me, so I only changed the error cases I came across and needed to know what the error was.

Previously the errors looked something like this:
```
thread 'main' panicked at 'Unable to build package in PKGBUILDS/sxmo/lisgd', src/main.rs:262:29
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

With the patch it looks like this:
```
Error: Unable to build package in PKGBUILDS/sxmo/lisgd

Caused by:
    0: Unable to copy file "/tmp/guzuta-pkgdest.ktzooXxar6Dx/lisgd-0.3.2-1-x86_64.pkg.tar.zst" to "./repo/sxmo/x86_64/lisgd-0.3.2-1-x86_64.pkg.tar.zst"
    1: No such file or directory (os error 2)
```